### PR TITLE
build(ng-dev/release): ignore version bumps when checking for ng-dev changes

### DIFF
--- a/tools/publish_to_github.sh
+++ b/tools/publish_to_github.sh
@@ -76,8 +76,8 @@ echo "Git configuration has been updated to match the last commit author. Publis
 
 git add -A
 
-if git diff-index --quiet HEAD --; then
-  echo "Skipping push as no changes occured between this push and the previous commit."
+if git diff-index --quiet -I"0\.0\.0-[a-f0-9]+" HEAD --; then
+  echo "Skipping push as no changes occurred between this push and the previous commit (ignoring version bumps)."
 else
   git commit -m "${buildCommitMessage}"
   git push ${authenticatedRepoUrl} ${branchName} --force


### PR DESCRIPTION
Updates the trailing builds publish script to use `git diff-index -I` for ignoring commits that only bump the ng-dev version without any underlying logical or code changes.