### PR TITLE
fix(ng-dev): prevent arbitrary code execution via option injection and symlinks

### DIFF
--- a/ng-dev/format/run-commands-parallel.ts
+++ b/ng-dev/format/run-commands-parallel.ts
@@ -9,6 +9,7 @@
 import {Bar} from 'cli-progress';
 import multimatch from 'multimatch';
 import {cpus} from 'os';
+import {lstatSync} from 'fs';
 
 import {ChildProcess, SpawnResult} from '../utils/child-process.js';
 import {Log} from '../utils/logging.js';
@@ -93,7 +94,11 @@ export function runFormatterInParallel(allFiles: string[], action: FormatterActi
       // Get the file and formatter for the next command.
       const {file, formatter} = nextCommand;
 
-      const [spawnCmd, ...spawnArgs] = [...formatter.commandFor(action).split(' '), file];
+      if (lstatSync(file).isSymbolicLink()) {
+        throw new Error(`Security violation: symlink detected for file ${file}`);
+      }
+
+      const [spawnCmd, ...spawnArgs] = [...formatter.commandFor(action).split(' '), '--', file];
 
       ChildProcess.spawn(spawnCmd, spawnArgs, {
         suppressErrorOnFailingExitCode: true,


### PR DESCRIPTION
This PR fixes an Arbitrary Code Execution (RCE) vulnerability in the `ng-dev format` command.

### Description
The formatter utility previously failed to separate command-line options from positional file paths using the standard `--` end-of-options delimiter. This allowed an attacker to execute arbitrary code by supplying a file named `--plugin=exploit.cjs`.

### Fix
- Added the `--` delimiter when spawning the formatter subprocess to correctly pass file paths as positional arguments.
- Added an explicit check using `fs.lstatSync` to prevent symlinks from being processed, throwing a hard synchronous error instead of attempting to sanitize them.