### PR TITLE
fix(ng-dev): prevent path traversal via package.json version string

### DIFF
--- a/ng-dev/misc/sync-module-bazel/sync-module-bazel.ts
+++ b/ng-dev/misc/sync-module-bazel/sync-module-bazel.ts
@@ -7,6 +7,7 @@
  */
 
 import {Log} from '../../utils/logging';
+import semver from 'semver';
 
 export interface PackageJson {
   engines?: {
@@ -158,6 +159,9 @@ async function processNodeToolchainArgs(
 
 /** Synchronizes the PNPM version and integrity in MODULE.bazel. */
 export async function syncPnpm(content: string, version: string): Promise<string> {
+  if (semver.valid(version) === null) {
+    throw new Error(`Invalid PNPM version: ${version}`);
+  }
   if (!PNPM_VERSION_REGEXP.test(content)) {
     return content;
   }
@@ -178,6 +182,9 @@ export async function syncPnpm(content: string, version: string): Promise<string
 
 /** Synchronizes the TypeScript version and integrity in MODULE.bazel. */
 export async function syncTypeScript(content: string, version: string): Promise<string> {
+  if (semver.valid(version) === null) {
+    throw new Error(`Invalid TypeScript version: ${version}`);
+  }
   if (!TS_VERSION_REGEXP.test(content)) {
     return content;
   }

--- a/poc.ts
+++ b/poc.ts
@@ -1,0 +1,18 @@
+import {syncPnpm} from './ng-dev/misc/sync-module-bazel/sync-module-bazel';
+
+async function main() {
+  try {
+    await syncPnpm('pnpm_version = "1.2.3"', '../../../../exploit-pkg/-/exploit-pkg-1.0.0');
+    console.error('FAIL: No error thrown');
+    process.exit(1);
+  } catch (e: any) {
+    if (e.message.includes('Invalid PNPM version')) {
+      console.log('SUCCESS: Error thrown correctly:', e.message);
+    } else {
+      console.error('FAIL: Wrong error thrown:', e.message);
+      process.exit(1);
+    }
+  }
+}
+
+main();


### PR DESCRIPTION
This PR fixes a critical path traversal vulnerability in sync-module-bazel by validating the version string against semver.